### PR TITLE
RTG acceleration improvements

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.c
+++ b/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.c
@@ -100,6 +100,51 @@ void fill_rect16(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t 
 	}
 }
 
+void copy_rect(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint16_t rect_sx, uint16_t rect_sy, uint32_t color_format)
+{
+	uint16_t w = rect_x2 - rect_x1 + 1, h = rect_y2 - rect_y1;
+	uint32_t* dp = fb + (rect_y1 * fb_pitch);
+	uint32_t* sp = fb + (rect_sy * fb_pitch);
+
+	int32_t line_step = fb_pitch;
+	int8_t x_reverse = 0;
+
+	if (rect_sy < rect_y1) {
+		line_step = -fb_pitch;
+		dp = fb + (rect_y2 * fb_pitch);
+		sp = fb + ((rect_sy + h) * fb_pitch);
+	}
+
+	if (rect_sx < rect_x1) {
+		x_reverse = 1;
+	}
+
+	for (uint16_t y_line = 0; y_line <= h; y_line++) {
+		switch(color_format) {
+			case MNTVA_COLOR_8BIT:
+				if (!x_reverse)
+					memcpy((uint8_t *)dp + rect_x1, (uint8_t *)sp + rect_sx, w);
+				else
+					memmove((uint8_t *)dp + rect_x1, (uint8_t *)sp + rect_sx, w);
+				break;
+			case MNTVA_COLOR_16BIT565:
+				if (!x_reverse)
+					memcpy((uint16_t *)dp + rect_x1, (uint16_t *)sp + rect_sx, w * 2);
+				else
+					memmove((uint16_t *)dp + rect_x1, (uint16_t *)sp + rect_sx, w * 2);
+				break;
+			case MNTVA_COLOR_32BIT:
+				if (!x_reverse)
+					memcpy(dp + rect_x1, sp + rect_sx, w * 4);
+				else
+					memmove(dp + rect_x1, sp + rect_sx, w * 4);
+				break;
+		}
+		dp += line_step;
+		sp += line_step;
+	}
+}
+
 void copy_rect32(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint16_t rect_sx, uint16_t rect_sy) {
 	int8_t ystep=1, xstep=1;
 	uint16_t tmp;

--- a/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.c
+++ b/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.c
@@ -39,6 +39,39 @@ void horizline(uint16_t x1, uint16_t x2, uint16_t y, uint32_t color) {
 	}
 }
 
+void fill_rect(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint32_t rect_rgb, uint32_t color_format)
+{
+	uint32_t* p = fb + (rect_y1 * fb_pitch);
+	uint16_t* p16;
+	uint16_t w = rect_x2 - rect_x1;
+	uint16_t x;
+
+	for (uint16_t cur_y = rect_y1; cur_y <= rect_y2; cur_y++) {
+		switch(color_format) {
+			case MNTVA_COLOR_8BIT:
+				memset((uint8_t *)p + rect_x1, (uint8_t)(rect_rgb >> 24), w + 1);
+				break;
+			case MNTVA_COLOR_16BIT565:
+				x = rect_x1;
+				p16 = (uint16_t *)p;
+				while(x <= rect_x2) {
+					p16[x++] = rect_rgb;
+				}
+				break;
+			case MNTVA_COLOR_32BIT:
+				x = rect_x1;
+				while(x <= rect_x2) {
+					p[x++] = rect_rgb;
+				}
+				break;
+			default:
+				// Unknown/unhandled color format.
+				break;
+		}
+		p += fb_pitch;
+	}
+}
+
 void fill_rect32(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint32_t rect_rgb) {
 	for (uint16_t y=rect_y1; y<=rect_y2; y++) {
 		uint32_t* p=fb+y*fb_pitch;

--- a/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.h
+++ b/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.h
@@ -24,6 +24,7 @@ typedef struct Vec2 {
 void set_fb(uint32_t* fb_, uint32_t pitch);
 void horizline(uint16_t x1, uint16_t x2, uint16_t y, uint32_t color);
 
+void fill_rect(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint32_t rect_rgb, uint32_t color_format);
 void fill_rect8(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint8_t rect_rgb);
 void fill_rect16(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint16_t rect_rgb);
 void fill_rect32(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint32_t rect_rgb);
@@ -35,3 +36,8 @@ void copy_rect32(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t 
 void fill_template(uint32_t bpp, uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2,
 		uint8_t draw_mode, uint8_t mask, uint32_t fg_color, uint32_t bg_color, uint16_t x_offset, uint16_t y_offset, uint8_t* tmpl_data, uint16_t templ_pitch, uint16_t loop_rows);
 
+#define MNTVA_COLOR_8BIT     0
+#define MNTVA_COLOR_16BIT565 1
+#define MNTVA_COLOR_32BIT    2
+#define MNTVA_COLOR_1BIT     3
+#define MNTVA_COLOR_15BIT    4

--- a/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.h
+++ b/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.h
@@ -41,12 +41,16 @@ void pattern_fill_rect(uint32_t color_format, uint16_t rect_x1, uint16_t rect_y1
 	uint16_t x_offset, uint16_t y_offset,
 	uint8_t *tmpl_data, uint16_t tmpl_pitch, uint16_t loop_rows);
 
+void draw_line(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y2, uint16_t pattern, uint16_t pattern_offset, uint32_t fg_color, uint32_t bg_color, uint32_t color_format, uint8_t mask, uint8_t draw_mode);
+void draw_line_solid(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y2, uint32_t fg_color, uint32_t color_format);
+
 #define MNTVA_COLOR_8BIT     0
 #define MNTVA_COLOR_16BIT565 1
 #define MNTVA_COLOR_32BIT    2
 #define MNTVA_COLOR_1BIT     3
 #define MNTVA_COLOR_15BIT    4
 
+/* Macros for keeping gfx.c a bit more tidy */
 #define SET_FG_PIXEL8(a) \
 	((uint8_t *)dp)[x+a] = u8_fg;
 #define SET_FG_PIXEL16(a) \
@@ -60,6 +64,11 @@ void pattern_fill_rect(uint32_t color_format, uint16_t rect_x1, uint16_t rect_y1
 	((uint16_t *)dp)[x+a] = bg_color;
 #define SET_BG_PIXEL32(a) \
 	dp[x+a] = bg_color;
+
+#define SET_FG_PIXEL8_MASK \
+	((uint8_t *)dp)[x] = u8_fg ^ (((uint8_t *)dp)[x] & (mask ^ 0xFF));
+#define SET_BG_PIXEL8_MASK \
+	((uint8_t *)dp)[x] = u8_bg ^ (((uint8_t *)dp)[x] & (mask ^ 0xFF));
 
 #define SET_FG_PIXEL \
 	switch (color_format) { \
@@ -152,11 +161,31 @@ void pattern_fill_rect(uint32_t color_format, uint16_t rect_x1, uint16_t rect_y1
 #define INVERT_PIXEL \
 	switch (color_format) { \
 		case MNTVA_COLOR_8BIT: \
-			((uint8_t *)dp)[x] ^= 0xFF; break; \
+			((uint8_t *)dp)[x] ^= mask; break; \
 		case MNTVA_COLOR_16BIT565: \
 			((uint16_t *)dp)[x] ^= 0xFFFF; break; \
 		case MNTVA_COLOR_32BIT: \
 			dp[x] ^= 0xFFFFFFFF; break; \
+	}
+
+#define INVERT_PIXEL_FG \
+	switch (color_format) { \
+		case MNTVA_COLOR_8BIT: \
+			((uint8_t *)dp)[x] = u8_fg ^ 0xFF; break; \
+		case MNTVA_COLOR_16BIT565: \
+			((uint16_t *)dp)[x] ^= fg_color; break; \
+		case MNTVA_COLOR_32BIT: \
+			dp[x] ^= fg_color; break; \
+	}
+
+#define INVERT_PIXEL_BG \
+	switch (color_format) { \
+		case MNTVA_COLOR_8BIT: \
+			((uint8_t *)dp)[x] ^= u8_bg; break; \
+		case MNTVA_COLOR_16BIT565: \
+			((uint16_t *)dp)[x] ^= bg_color; break; \
+		case MNTVA_COLOR_32BIT: \
+			dp[x] ^= bg_color; break; \
 	}
 
 #define INVERT_PIXELS \

--- a/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.h
+++ b/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.h
@@ -29,6 +29,7 @@ void fill_rect8(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t r
 void fill_rect16(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint16_t rect_rgb);
 void fill_rect32(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint32_t rect_rgb);
 
+void copy_rect(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint16_t rect_sx, uint16_t rect_sy, uint32_t color_format);
 void copy_rect8(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint16_t rect_sx, uint16_t rect_sy);
 void copy_rect16(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint16_t rect_sx, uint16_t rect_sy);
 void copy_rect32(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2, uint16_t rect_sx, uint16_t rect_sy);

--- a/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.h
+++ b/ZZ9000_proto.sdk/ZZ9000Test/src/gfx.h
@@ -36,9 +36,159 @@ void copy_rect32(uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t 
 
 void fill_template(uint32_t bpp, uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2,
 		uint8_t draw_mode, uint8_t mask, uint32_t fg_color, uint32_t bg_color, uint16_t x_offset, uint16_t y_offset, uint8_t* tmpl_data, uint16_t templ_pitch, uint16_t loop_rows);
+void pattern_fill_rect(uint32_t color_format, uint16_t rect_x1, uint16_t rect_y1, uint16_t rect_x2, uint16_t rect_y2,
+	uint8_t draw_mode, uint8_t mask, uint32_t fg_color, uint32_t bg_color,
+	uint16_t x_offset, uint16_t y_offset,
+	uint8_t *tmpl_data, uint16_t tmpl_pitch, uint16_t loop_rows);
 
 #define MNTVA_COLOR_8BIT     0
 #define MNTVA_COLOR_16BIT565 1
 #define MNTVA_COLOR_32BIT    2
 #define MNTVA_COLOR_1BIT     3
 #define MNTVA_COLOR_15BIT    4
+
+#define SET_FG_PIXEL8(a) \
+	((uint8_t *)dp)[x+a] = u8_fg;
+#define SET_FG_PIXEL16(a) \
+	((uint16_t *)dp)[x+a] = fg_color;
+#define SET_FG_PIXEL32(a) \
+	dp[x+a] = fg_color;
+
+#define SET_BG_PIXEL8(a) \
+	((uint8_t *)dp)[x+a] = u8_bg;
+#define SET_BG_PIXEL16(a) \
+	((uint16_t *)dp)[x+a] = bg_color;
+#define SET_BG_PIXEL32(a) \
+	dp[x+a] = bg_color;
+
+#define SET_FG_PIXEL \
+	switch (color_format) { \
+		case MNTVA_COLOR_8BIT: \
+			SET_FG_PIXEL8(0); break; \
+		case MNTVA_COLOR_16BIT565: \
+			SET_FG_PIXEL16(0); break; \
+		case MNTVA_COLOR_32BIT: \
+			SET_FG_PIXEL32(0); break; \
+	}
+
+#define SET_BG_PIXEL \
+	switch (color_format) { \
+		case MNTVA_COLOR_8BIT: \
+			SET_BG_PIXEL8(0); break; \
+		case MNTVA_COLOR_16BIT565: \
+			SET_BG_PIXEL16(0); break; \
+		case MNTVA_COLOR_32BIT: \
+			SET_BG_PIXEL32(0); break; \
+	}
+
+#define SET_FG_PIXELS \
+	switch (color_format) { \
+		case MNTVA_COLOR_8BIT: \
+			if (cur_byte & 0x80) SET_FG_PIXEL8(0); \
+			if (cur_byte & 0x40) SET_FG_PIXEL8(1); \
+			if (cur_byte & 0x20) SET_FG_PIXEL8(2); \
+			if (cur_byte & 0x10) SET_FG_PIXEL8(3); \
+			if (cur_byte & 0x08) SET_FG_PIXEL8(4); \
+			if (cur_byte & 0x04) SET_FG_PIXEL8(5); \
+			if (cur_byte & 0x02) SET_FG_PIXEL8(6); \
+			if (cur_byte & 0x01) SET_FG_PIXEL8(7); \
+			break; \
+		case MNTVA_COLOR_16BIT565: \
+			if (cur_byte & 0x80) SET_FG_PIXEL16(0); \
+			if (cur_byte & 0x40) SET_FG_PIXEL16(1); \
+			if (cur_byte & 0x20) SET_FG_PIXEL16(2); \
+			if (cur_byte & 0x10) SET_FG_PIXEL16(3); \
+			if (cur_byte & 0x08) SET_FG_PIXEL16(4); \
+			if (cur_byte & 0x04) SET_FG_PIXEL16(5); \
+			if (cur_byte & 0x02) SET_FG_PIXEL16(6); \
+			if (cur_byte & 0x01) SET_FG_PIXEL16(7); \
+			break; \
+		case MNTVA_COLOR_32BIT: \
+			if (cur_byte & 0x80) SET_FG_PIXEL32(0); \
+			if (cur_byte & 0x40) SET_FG_PIXEL32(1); \
+			if (cur_byte & 0x20) SET_FG_PIXEL32(2); \
+			if (cur_byte & 0x10) SET_FG_PIXEL32(3); \
+			if (cur_byte & 0x08) SET_FG_PIXEL32(4); \
+			if (cur_byte & 0x04) SET_FG_PIXEL32(5); \
+			if (cur_byte & 0x02) SET_FG_PIXEL32(6); \
+			if (cur_byte & 0x01) SET_FG_PIXEL32(7); \
+			break; \
+	}
+
+#define SET_FG_OR_BG_PIXELS \
+	switch (color_format) { \
+		case MNTVA_COLOR_8BIT: \
+			if (cur_byte & 0x80) SET_FG_PIXEL8(0) else SET_BG_PIXEL8(0) \
+			if (cur_byte & 0x40) SET_FG_PIXEL8(1) else SET_BG_PIXEL8(1) \
+			if (cur_byte & 0x20) SET_FG_PIXEL8(2) else SET_BG_PIXEL8(2) \
+			if (cur_byte & 0x10) SET_FG_PIXEL8(3) else SET_BG_PIXEL8(3) \
+			if (cur_byte & 0x08) SET_FG_PIXEL8(4) else SET_BG_PIXEL8(4) \
+			if (cur_byte & 0x04) SET_FG_PIXEL8(5) else SET_BG_PIXEL8(5) \
+			if (cur_byte & 0x02) SET_FG_PIXEL8(6) else SET_BG_PIXEL8(6) \
+			if (cur_byte & 0x01) SET_FG_PIXEL8(7) else SET_BG_PIXEL8(7) \
+			break; \
+		case MNTVA_COLOR_16BIT565: \
+			if (cur_byte & 0x80) SET_FG_PIXEL16(0) else SET_BG_PIXEL16(0) \
+			if (cur_byte & 0x40) SET_FG_PIXEL16(1) else SET_BG_PIXEL16(1) \
+			if (cur_byte & 0x20) SET_FG_PIXEL16(2) else SET_BG_PIXEL16(2) \
+			if (cur_byte & 0x10) SET_FG_PIXEL16(3) else SET_BG_PIXEL16(3) \
+			if (cur_byte & 0x08) SET_FG_PIXEL16(4) else SET_BG_PIXEL16(4) \
+			if (cur_byte & 0x04) SET_FG_PIXEL16(5) else SET_BG_PIXEL16(5) \
+			if (cur_byte & 0x02) SET_FG_PIXEL16(6) else SET_BG_PIXEL16(6) \
+			if (cur_byte & 0x01) SET_FG_PIXEL16(7) else SET_BG_PIXEL16(7) \
+			break; \
+		case MNTVA_COLOR_32BIT: \
+			if (cur_byte & 0x80) SET_FG_PIXEL32(0) else SET_BG_PIXEL32(0) \
+			if (cur_byte & 0x40) SET_FG_PIXEL32(1) else SET_BG_PIXEL32(1) \
+			if (cur_byte & 0x20) SET_FG_PIXEL32(2) else SET_BG_PIXEL32(2) \
+			if (cur_byte & 0x10) SET_FG_PIXEL32(3) else SET_BG_PIXEL32(3) \
+			if (cur_byte & 0x08) SET_FG_PIXEL32(4) else SET_BG_PIXEL32(4) \
+			if (cur_byte & 0x04) SET_FG_PIXEL32(5) else SET_BG_PIXEL32(5) \
+			if (cur_byte & 0x02) SET_FG_PIXEL32(6) else SET_BG_PIXEL32(6) \
+			if (cur_byte & 0x01) SET_FG_PIXEL32(7) else SET_BG_PIXEL32(7) \
+			break; \
+	}
+
+#define INVERT_PIXEL \
+	switch (color_format) { \
+		case MNTVA_COLOR_8BIT: \
+			((uint8_t *)dp)[x] ^= 0xFF; break; \
+		case MNTVA_COLOR_16BIT565: \
+			((uint16_t *)dp)[x] ^= 0xFFFF; break; \
+		case MNTVA_COLOR_32BIT: \
+			dp[x] ^= 0xFFFFFFFF; break; \
+	}
+
+#define INVERT_PIXELS \
+	switch (color_format) { \
+		case MNTVA_COLOR_8BIT: \
+			if (cur_byte & 0x80) ((uint8_t *)dp)[x] ^= 0xFF; \
+			if (cur_byte & 0x40) ((uint8_t *)dp)[x+1] ^= 0xFF; \
+			if (cur_byte & 0x20) ((uint8_t *)dp)[x+2] ^= 0xFF; \
+			if (cur_byte & 0x10) ((uint8_t *)dp)[x+3] ^= 0xFF; \
+			if (cur_byte & 0x08) ((uint8_t *)dp)[x+4] ^= 0xFF; \
+			if (cur_byte & 0x04) ((uint8_t *)dp)[x+5] ^= 0xFF; \
+			if (cur_byte & 0x02) ((uint8_t *)dp)[x+6] ^= 0xFF; \
+			if (cur_byte & 0x01) ((uint8_t *)dp)[x+7] ^= 0xFF; \
+			break; \
+		case MNTVA_COLOR_16BIT565: \
+			if (cur_byte & 0x80) ((uint16_t *)dp)[x] ^= 0xFFFF; \
+			if (cur_byte & 0x40) ((uint16_t *)dp)[x+1] ^= 0xFFFF; \
+			if (cur_byte & 0x20) ((uint16_t *)dp)[x+2] ^= 0xFFFF; \
+			if (cur_byte & 0x10) ((uint16_t *)dp)[x+3] ^= 0xFFFF; \
+			if (cur_byte & 0x08) ((uint16_t *)dp)[x+4] ^= 0xFFFF; \
+			if (cur_byte & 0x04) ((uint16_t *)dp)[x+5] ^= 0xFFFF; \
+			if (cur_byte & 0x02) ((uint16_t *)dp)[x+6] ^= 0xFFFF; \
+			if (cur_byte & 0x01) ((uint16_t *)dp)[x+7] ^= 0xFFFF; \
+			break; \
+		case MNTVA_COLOR_32BIT: \
+			if (cur_byte & 0x80) dp[x] ^= 0xFFFFFFFF; \
+			if (cur_byte & 0x40) dp[x+1] ^= 0xFFFFFFFF; \
+			if (cur_byte & 0x20) dp[x+2] ^= 0xFFFFFFFF; \
+			if (cur_byte & 0x10) dp[x+3] ^= 0xFFFFFFFF; \
+			if (cur_byte & 0x08) dp[x+4] ^= 0xFFFFFFFF; \
+			if (cur_byte & 0x04) dp[x+5] ^= 0xFFFFFFFF; \
+			if (cur_byte & 0x02) dp[x+6] ^= 0xFFFFFFFF; \
+			if (cur_byte & 0x01) dp[x+7] ^= 0xFFFFFFFF; \
+			break; \
+	}

--- a/ZZ9000_proto.sdk/ZZ9000Test/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000Test/src/main.c
@@ -1166,7 +1166,8 @@ int main()
 						printf("blitter_src_pitch: %d\n\n", blitter_src_pitch);*/
 					}
 
-					fill_template(bpp, rect_x1, rect_y1, rect_x2, rect_y2, draw_mode, 0xff, rect_rgb, rect_rgb2, rect_x3, rect_y3, tmpl_data, blitter_src_pitch, loop_rows);
+					//fill_template(bpp, rect_x1, rect_y1, rect_x2, rect_y2, draw_mode, 0xff, rect_rgb, rect_rgb2, rect_x3, rect_y3, tmpl_data, blitter_src_pitch, loop_rows);
+					pattern_fill_rect((blitter_colormode & 0x0F), rect_x1, rect_y1, rect_x2, rect_y2, draw_mode, 0xff, rect_rgb, rect_rgb2, rect_x3, rect_y3, tmpl_data, blitter_src_pitch, loop_rows);
 				}
 				else if (zaddr==MNT_BASE_BLITTER_COLORMODE) {
 					blitter_colormode = zdata;

--- a/ZZ9000_proto.sdk/ZZ9000Test/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000Test/src/main.c
@@ -1169,6 +1169,17 @@ int main()
 					//fill_template(bpp, rect_x1, rect_y1, rect_x2, rect_y2, draw_mode, 0xff, rect_rgb, rect_rgb2, rect_x3, rect_y3, tmpl_data, blitter_src_pitch, loop_rows);
 					pattern_fill_rect((blitter_colormode & 0x0F), rect_x1, rect_y1, rect_x2, rect_y2, draw_mode, 0xff, rect_rgb, rect_rgb2, rect_x3, rect_y3, tmpl_data, blitter_src_pitch, loop_rows);
 				}
+				else if (zaddr==MNT_BASE_RECTOP+0xA6) {
+					// DrawLine
+					uint8_t draw_mode = blitter_colormode >> 8;
+					set_fb((uint32_t*)((u32)framebuffer+blitter_dst_offset), blitter_dst_pitch);
+
+					// rect_x3 contains the pattern, if all bits are set for both the mask and the pattern, there's no point in passing non-essential data to the pattern/mask aware function.
+					if (rect_x3 == 0xFFFF && zdata == 0xFF)
+						draw_line_solid(rect_x1, rect_y1, rect_x2, rect_y2, rect_rgb, (blitter_colormode & 0x0F));
+					else
+						draw_line(rect_x1, rect_y1, rect_x2, rect_y2, rect_x3, rect_y3, rect_rgb, rect_rgb2, (blitter_colormode & 0x0F), zdata, draw_mode);
+				}
 				else if (zaddr==MNT_BASE_BLITTER_COLORMODE) {
 					blitter_colormode = zdata;
 				}

--- a/ZZ9000_proto.sdk/ZZ9000Test/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000Test/src/main.c
@@ -51,12 +51,6 @@ typedef u8 uint8_t;
 #define IIC_SCLK_RATE	400000
 #define GPIO_DEVICE_ID		XPAR_XGPIOPS_0_DEVICE_ID
 
-#define MNTVA_COLOR_8BIT     0
-#define MNTVA_COLOR_16BIT565 1
-#define MNTVA_COLOR_32BIT    2
-#define MNTVA_COLOR_1BIT     3
-#define MNTVA_COLOR_15BIT    4
-
 #define I2C_PAUSE 10
 
 // I2C controller instance
@@ -1113,13 +1107,15 @@ int main()
 
 					set_fb((uint32_t*)((u32)framebuffer+blitter_dst_offset), blitter_dst_pitch);
 
-					if (blitter_colormode==MNTVA_COLOR_16BIT565) {
+					fill_rect(rect_x1, rect_y1, rect_x2, rect_y2, rect_rgb, blitter_colormode);
+
+					/*if (blitter_colormode==MNTVA_COLOR_16BIT565) {
 						fill_rect16(rect_x1,rect_y1,rect_x2,rect_y2,rect_rgb);
 					} else if (blitter_colormode==MNTVA_COLOR_8BIT) {
 						fill_rect8(rect_x1,rect_y1,rect_x2,rect_y2,rect_rgb>>24);
 					} else if (blitter_colormode==MNTVA_COLOR_32BIT) {
 						fill_rect32(rect_x1,rect_y1,rect_x2,rect_y2,rect_rgb);
-					}
+					}*/
 				}
 				else if (zaddr==MNT_BASE_RECTOP+0x14) {
 					set_fb((uint32_t*)((u32)framebuffer+blitter_dst_offset), blitter_dst_pitch);

--- a/ZZ9000_proto.sdk/ZZ9000Test/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000Test/src/main.c
@@ -1118,10 +1118,12 @@ int main()
 					}*/
 				}
 				else if (zaddr==MNT_BASE_RECTOP+0x14) {
+					// copy rectangle
 					set_fb((uint32_t*)((u32)framebuffer+blitter_dst_offset), blitter_dst_pitch);
 
-					// copy rectangle
-					if (blitter_colormode==MNTVA_COLOR_16BIT565) {
+					copy_rect(rect_x1, rect_y1, rect_x2, rect_y2, rect_x3, rect_y3, blitter_colormode);
+
+					/*if (blitter_colormode==MNTVA_COLOR_16BIT565) {
 						// 16 bit
 						copy_rect16(rect_x1,rect_y1,rect_x2,rect_y2,rect_x3,rect_y3);
 					} else if (blitter_colormode==MNTVA_COLOR_8BIT) {
@@ -1130,7 +1132,7 @@ int main()
 					} else {
 						// 32 bit
 						copy_rect32(rect_x1,rect_y1,rect_x2,rect_y2,rect_x3,rect_y3);
-					}
+					}*/
 					Xil_DCacheFlush();
 				}
 				else if (zaddr==MNT_BASE_RECTOP+0x16) {


### PR DESCRIPTION
Slight optimization and revision of fill/copy rect and pattern/template fill rect.
Fill rect should be about 17% faster and copy rect about 25%. The speedup for pattern fill rect isn't as big, but it keeps the bits intact for each pattern byte, so it should be easier to implement support for the mask.

I've left the original functionality intact, just in case I've missed something.